### PR TITLE
Decouple the secrets from app service into the logic of the auth backend

### DIFF
--- a/internal/authbackend/authbackend.go
+++ b/internal/authbackend/authbackend.go
@@ -11,12 +11,18 @@ type OIDCApp struct {
 	ID          string
 	Name        string
 	CallBackURL string
-	Secret      string
+}
+
+// OIDCAppRegistryData is extra information that the user can use to communicate with the
+// auth backend.
+type OIDCAppRegistryData struct {
+	ClientID     string
+	ClientSecret string
 }
 
 // AppRegisterer knows how to register OIDC apps on backends.
 type AppRegisterer interface {
-	RegisterApp(ctx context.Context, app OIDCApp) error
+	RegisterApp(ctx context.Context, app OIDCApp) (*OIDCAppRegistryData, error)
 	UnregisterApp(ctx context.Context, appID string) error
 }
 

--- a/internal/authbackend/authbackendmock/app_registerer.go
+++ b/internal/authbackend/authbackendmock/app_registerer.go
@@ -12,17 +12,26 @@ type AppRegisterer struct {
 }
 
 // RegisterApp provides a mock function with given fields: ctx, app
-func (_m *AppRegisterer) RegisterApp(ctx context.Context, app authbackend.OIDCApp) error {
+func (_m *AppRegisterer) RegisterApp(ctx context.Context, app authbackend.OIDCApp) (*authbackend.OIDCAppRegistryData, error) {
 	ret := _m.Called(ctx, app)
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, authbackend.OIDCApp) error); ok {
+	var r0 *authbackend.OIDCAppRegistryData
+	if rf, ok := ret.Get(0).(func(context.Context, authbackend.OIDCApp) *authbackend.OIDCAppRegistryData); ok {
 		r0 = rf(ctx, app)
 	} else {
-		r0 = ret.Error(0)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*authbackend.OIDCAppRegistryData)
+		}
 	}
 
-	return r0
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, authbackend.OIDCApp) error); ok {
+		r1 = rf(ctx, app)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // UnregisterApp provides a mock function with given fields: ctx, appID

--- a/internal/proxy/oauth2proxy/oauth2proxy.go
+++ b/internal/proxy/oauth2proxy/oauth2proxy.go
@@ -106,9 +106,9 @@ func (p provisioner) provisionDeployment(ctx context.Context, settings proxy.OID
 							Image: "quay.io/oauth2-proxy/oauth2-proxy:v5.1.0",
 							Args: []string{
 								fmt.Sprintf(`--oidc-issuer-url=%s`, settings.IssuerURL),
-								fmt.Sprintf(`--client-id=%s`, settings.AppID),
+								fmt.Sprintf(`--client-id=%s`, settings.ClientID),
 								// TODO(slok): Create asecret and inject as env var.
-								fmt.Sprintf(`--client-secret=%s`, settings.AppSecret),
+								fmt.Sprintf(`--client-secret=%s`, settings.ClientSecret),
 								fmt.Sprintf(`--http-address=0.0.0.0:%d`, proxyInternalPort),
 								fmt.Sprintf(`--redirect-url=%s/oauth2/callback`, settings.URL),
 								fmt.Sprintf(`--upstream=%s`, settings.UpstreamURL),

--- a/internal/proxy/oauth2proxy/oauth2proxy_test.go
+++ b/internal/proxy/oauth2proxy/oauth2proxy_test.go
@@ -25,8 +25,8 @@ func getBaseSettings() proxy.OIDCProxySettings {
 		URL:              "https://my-app.my-cluster.dev",
 		UpstreamURL:      "http://my-app.my-ns.svc.cluster.local:8080",
 		IssuerURL:        "https://dex.my-cluster.dev",
-		AppID:            "my-app-bilrost",
-		AppSecret:        "my-secret",
+		ClientID:         "my-app-bilrost",
+		ClientSecret:     "my-secret",
 		Scopes:           []string{"openid", "email", "profile", "groups", "offline_access"},
 		IngressNamespace: "my-ns",
 		IngressName:      "my-app",
@@ -60,7 +60,7 @@ func getBaseDeployment() *appsv1.Deployment {
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
-						corev1.Container{
+						{
 							Name:  "app",
 							Image: "quay.io/oauth2-proxy/oauth2-proxy:v5.1.0",
 							Args: []string{
@@ -78,7 +78,7 @@ func getBaseDeployment() *appsv1.Deployment {
 								`--email-domain=*`,
 							},
 							Ports: []corev1.ContainerPort{
-								corev1.ContainerPort{
+								{
 									ContainerPort: 4180,
 									Name:          "http",
 									Protocol:      "TCP",
@@ -109,7 +109,7 @@ func getBaseService() *corev1.Service {
 			Type:     "ClusterIP",
 			Selector: baseLabels,
 			Ports: []corev1.ServicePort{
-				corev1.ServicePort{
+				{
 					Port:       80,
 					Name:       "http",
 					TargetPort: intstr.FromInt(4180),

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -12,10 +12,10 @@ type OIDCProxySettings struct {
 	UpstreamURL string
 	//IssuerURL is the public URL where the auth service is issuing the tokens (e.g Dex public URL).
 	IssuerURL string
-	// AppID is the id that identifies the app in the auth service.
-	AppID string
-	// AppSecret is the secret used for the app to communicate with the auth service.
-	AppSecret string
+	// ClientID is the id that identifies the app in the auth service.
+	ClientID string
+	// ClientSecret is the secret used for the app to communicate with the auth service.
+	ClientSecret string
 	// Scopes are the Oauth/OIDC scopes asked to the auth service to set that info in the token.
 	Scopes []string
 	// IngressName is the app's ingress, the entrypoint to the application that we must secure.

--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -115,9 +115,8 @@ func (s service) SecureApp(ctx context.Context, app model.App) error {
 		ID:          app.ID,
 		Name:        app.ID,
 		CallBackURL: fmt.Sprintf("https://%s/oauth2/callback", app.Host), // TODO(slok): Configurable based on the proxy.
-		Secret:      "TODO",                                              // TODO(slok): Need a way of setting a proper secret.
 	}
-	err = abReg.RegisterApp(ctx, oa)
+	oaRes, err := abReg.RegisterApp(ctx, oa)
 	if err != nil {
 		return fmt.Errorf("could not register oauth application on backend: %w", err)
 	}
@@ -154,8 +153,8 @@ func (s service) SecureApp(ctx context.Context, app model.App) error {
 		// TODO(slok): Is always http? https?
 		UpstreamURL:      fmt.Sprintf("http://%s:%d", host, port),
 		IssuerURL:        abPublicURL,
-		AppID:            oa.ID,
-		AppSecret:        oa.Secret,
+		ClientID:         oaRes.ClientID,
+		ClientSecret:     oaRes.ClientSecret,
 		IngressName:      app.Ingress.Name,
 		IngressNamespace: app.Ingress.Namespace,
 	}

--- a/internal/security/security_test.go
+++ b/internal/security/security_test.go
@@ -66,9 +66,12 @@ func TestSecureApp(t *testing.T) {
 					ID:          "test-ns/my-app",
 					Name:        "test-ns/my-app",
 					CallBackURL: "https://my.app.slok.dev/oauth2/callback",
-					Secret:      "TODO",
 				}
-				m.abAppReg.On("RegisterApp", mock.Anything, expOIDCApp).Once().Return(nil)
+				oidcAppReg := &authbackend.OIDCAppRegistryData{
+					ClientID:     "app1",
+					ClientSecret: "my5cr37",
+				}
+				m.abAppReg.On("RegisterApp", mock.Anything, expOIDCApp).Once().Return(oidcAppReg, nil)
 
 				// The original information should be backup up.
 				expData := backup.Data{
@@ -91,8 +94,8 @@ func TestSecureApp(t *testing.T) {
 					URL:              "https://my.app.slok.dev",
 					UpstreamURL:      "http://internal-app.my-ns.svc.cluster.local:8080",
 					IssuerURL:        "https://test-dex.dev",
-					AppID:            "test-ns/my-app",
-					AppSecret:        "TODO",
+					ClientID:         "app1",
+					ClientSecret:     "my5cr37",
 					IngressName:      "my-app",
 					IngressNamespace: "test-ns",
 				}
@@ -131,9 +134,12 @@ func TestSecureApp(t *testing.T) {
 					ID:          "test-ns/my-app",
 					Name:        "test-ns/my-app",
 					CallBackURL: "https://my.app.slok.dev/oauth2/callback",
-					Secret:      "TODO",
 				}
-				m.abAppReg.On("RegisterApp", mock.Anything, expOIDCApp).Once().Return(nil)
+				oidcAppReg := &authbackend.OIDCAppRegistryData{
+					ClientID:     "app1",
+					ClientSecret: "my5cr37",
+				}
+				m.abAppReg.On("RegisterApp", mock.Anything, expOIDCApp).Once().Return(oidcAppReg, nil)
 
 				// The original information is already there, we return the original upstream.
 				expData := backup.Data{
@@ -160,8 +166,8 @@ func TestSecureApp(t *testing.T) {
 					URL:              "https://my.app.slok.dev",
 					UpstreamURL:      "http://internal-app.my-ns.svc.cluster.local:8080",
 					IssuerURL:        "https://test-dex.dev",
-					AppID:            "test-ns/my-app",
-					AppSecret:        "TODO",
+					ClientID:         "app1",
+					ClientSecret:     "my5cr37",
 					IngressName:      "my-app",
 					IngressNamespace: "test-ns",
 				}
@@ -179,7 +185,7 @@ func TestSecureApp(t *testing.T) {
 		"Failing while registering the app on the auth backend should stop the process with failure.": {
 			mock: func(m testMocks) {
 				m.abRepo.On("GetAuthBackend", mock.Anything, mock.Anything).Once().Return(&model.AuthBackend{}, nil)
-				m.abAppReg.On("RegisterApp", mock.Anything, mock.Anything).Once().Return(fmt.Errorf("wanted error"))
+				m.abAppReg.On("RegisterApp", mock.Anything, mock.Anything).Once().Return(nil, fmt.Errorf("wanted error"))
 			},
 			expErr: true,
 		},
@@ -187,7 +193,7 @@ func TestSecureApp(t *testing.T) {
 		"Failing while backuping the data should stop the process with failure.": {
 			mock: func(m testMocks) {
 				m.abRepo.On("GetAuthBackend", mock.Anything, mock.Anything).Once().Return(&model.AuthBackend{}, nil)
-				m.abAppReg.On("RegisterApp", mock.Anything, mock.Anything).Once().Return(nil)
+				m.abAppReg.On("RegisterApp", mock.Anything, mock.Anything).Once().Return(&authbackend.OIDCAppRegistryData{}, nil)
 				m.backupper.On("BackupOrGet", mock.Anything, mock.Anything, mock.Anything).Once().Return(nil, fmt.Errorf("wanted error"))
 			},
 			expErr: true,
@@ -196,7 +202,7 @@ func TestSecureApp(t *testing.T) {
 		"Failing while translating the service to a URL should stop the process with failure.": {
 			mock: func(m testMocks) {
 				m.abRepo.On("GetAuthBackend", mock.Anything, mock.Anything).Once().Return(&model.AuthBackend{}, nil)
-				m.abAppReg.On("RegisterApp", mock.Anything, mock.Anything).Once().Return(nil)
+				m.abAppReg.On("RegisterApp", mock.Anything, mock.Anything).Once().Return(&authbackend.OIDCAppRegistryData{}, nil)
 				m.backupper.On("BackupOrGet", mock.Anything, mock.Anything, mock.Anything).Once().Return(nil, nil)
 				m.svcTranslator.On("GetServiceHostAndPort", mock.Anything, mock.Anything).Once().Return("", 0, fmt.Errorf("wanted error"))
 			},
@@ -206,7 +212,7 @@ func TestSecureApp(t *testing.T) {
 		"Failing while provisioning the proxy should stop the process with failure.": {
 			mock: func(m testMocks) {
 				m.abRepo.On("GetAuthBackend", mock.Anything, mock.Anything).Once().Return(&model.AuthBackend{}, nil)
-				m.abAppReg.On("RegisterApp", mock.Anything, mock.Anything).Once().Return(nil)
+				m.abAppReg.On("RegisterApp", mock.Anything, mock.Anything).Once().Return(&authbackend.OIDCAppRegistryData{}, nil)
 				m.backupper.On("BackupOrGet", mock.Anything, mock.Anything, mock.Anything).Once().Return(nil, nil)
 				m.svcTranslator.On("GetServiceHostAndPort", mock.Anything, mock.Anything).Once().Return("", 0, nil)
 				m.oidcProxyProv.On("Provision", mock.Anything, mock.Anything).Once().Return(fmt.Errorf("wanted error"))


### PR DESCRIPTION
Now the secrets should be generated/retrieved from the auth backend implementation and received as a result on the application server, that will use this data to pass it to the proxy.

This is because each of the auth backends can manage differently the secret retrieval, for example on dex we can autogenerate and send to dex the secret, instead of on auth0, we will call the API to register a new app/client and the API will return us the Client secret.