### PR TITLE
Fix the name of the secret created for dex clients using a fixed length with md5

### DIFF
--- a/internal/authbackend/dex/dex.go
+++ b/internal/authbackend/dex/dex.go
@@ -2,11 +2,10 @@ package dex
 
 import (
 	"context"
+	"crypto/md5"
 	"crypto/rand"
-	"encoding/base32"
 	"encoding/base64"
 	"fmt"
-	"strings"
 
 	dexapi "github.com/dexidp/dex/api"
 	"google.golang.org/grpc"
@@ -233,6 +232,6 @@ func (a appRegisterer) UnregisterApp(ctx context.Context, appID string) error {
 }
 
 func getSecretName(id string) string {
-	b32ID := base32.HexEncoding.WithPadding(base32.NoPadding).EncodeToString([]byte(id))
-	return fmt.Sprintf("bilrost-dex-client-%s", strings.ToLower(b32ID))
+	checksum := md5.Sum([]byte(id))
+	return fmt.Sprintf("bilrost-dex-cli-%x", checksum)
 }

--- a/internal/authbackend/dex/dex_test.go
+++ b/internal/authbackend/dex/dex_test.go
@@ -36,7 +36,7 @@ func getBaseConfig() dex.AppRegistererConfig {
 func getBaseSecret() *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "bilrost-dex-client-ehin6t1dd5i0",
+			Name:      "bilrost-dex-cli-361dc45aacd2d2a1961554d12a2d666b",
 			Namespace: "test-ns",
 			Annotations: map[string]string{
 				"bilrost.slok.dev/dex-client-id": "test-id",
@@ -45,7 +45,7 @@ func getBaseSecret() *corev1.Secret {
 				"app.kubernetes.io/managed-by": "bilrost",
 				"app.kubernetes.io/name":       "bilrost",
 				"app.kubernetes.io/component":  "dex-client-data",
-				"app.kubernetes.io/instance":   "bilrost-dex-client-ehin6t1dd5i0",
+				"app.kubernetes.io/instance":   "bilrost-dex-cli-361dc45aacd2d2a1961554d12a2d666b",
 			},
 		},
 		Type: corev1.SecretTypeOpaque,
@@ -123,7 +123,7 @@ func TestRegisterApp(t *testing.T) {
 			mock: func(c *dexmock.Client, k *dexmock.KubernetesRepository) {
 				// Ask for the secret on Kubernetes.
 				expErr := &kubeerrors.StatusError{ErrStatus: metav1.Status{Reason: metav1.StatusReasonNotFound}}
-				k.On("GetSecret", mock.Anything, "test-ns", "bilrost-dex-client-ehin6t1dd5i0").Once().Return(nil, expErr)
+				k.On("GetSecret", mock.Anything, "test-ns", "bilrost-dex-cli-361dc45aacd2d2a1961554d12a2d666b").Once().Return(nil, expErr)
 
 				// No secret, should create a new one using our generator.
 				expSecret := getBaseSecret()
@@ -144,7 +144,7 @@ func TestRegisterApp(t *testing.T) {
 				// Ask for the secret on Kubernetes.
 				expSecret := getBaseSecret()
 				expSecret.Data["clientSecret"] = []byte("old-secret")
-				k.On("GetSecret", mock.Anything, "test-ns", "bilrost-dex-client-ehin6t1dd5i0").Once().Return(expSecret, nil)
+				k.On("GetSecret", mock.Anything, "test-ns", "bilrost-dex-cli-361dc45aacd2d2a1961554d12a2d666b").Once().Return(expSecret, nil)
 
 				expReq := getBaseDexCreateRequest()
 				expReq.Client.Secret = "old-secret"
@@ -164,7 +164,7 @@ func TestRegisterApp(t *testing.T) {
 				// Ask for the secret on Kubernetes.
 				storedSecret := getBaseSecret()
 				storedSecret.Data["clientSecret"] = []byte("") // Force creation.
-				k.On("GetSecret", mock.Anything, "test-ns", "bilrost-dex-client-ehin6t1dd5i0").Once().Return(storedSecret, nil)
+				k.On("GetSecret", mock.Anything, "test-ns", "bilrost-dex-cli-361dc45aacd2d2a1961554d12a2d666b").Once().Return(storedSecret, nil)
 
 				// Empty secret, should create a new one using our generator.
 				expSecret := getBaseSecret()
@@ -238,7 +238,7 @@ func TestUnregisterApp(t *testing.T) {
 			mock: func(c *dexmock.Client, k *dexmock.KubernetesRepository) {
 				expReq := &dexapi.DeleteClientReq{Id: "test-id"}
 				c.On("DeleteClient", mock.Anything, expReq).Once().Return(nil, nil)
-				k.On("DeleteSecret", mock.Anything, "test-ns", "bilrost-dex-client-ehin6t1dd5i0").Once().Return(nil)
+				k.On("DeleteSecret", mock.Anything, "test-ns", "bilrost-dex-cli-361dc45aacd2d2a1961554d12a2d666b").Once().Return(nil)
 			},
 		},
 	}


### PR DESCRIPTION
Could happen that if the name of the ingress + namespace was too long, the base32 resulting name when dex implementation creates a secret to store the OIDC client secret, would fail because of the lenght of the kubernetes secret name, to fix this instead of using unbounded length base32 based names, we changed for a fixed length md5 generated names.