### PR TITLE
Add timeout to http server shutdown execution

### DIFF
--- a/cmd/bilrost/main.go
+++ b/cmd/bilrost/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/oklog/run"
 	"github.com/prometheus/client_golang/prometheus"
@@ -112,7 +113,9 @@ func Run() error {
 				return server.ListenAndServe()
 			},
 			func(_ error) {
-				err := server.Shutdown(context.Background())
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+				err := server.Shutdown(ctx)
 				if err != nil {
 					logger.Errorf("error shutting down metrics server: %w", err)
 				}


### PR DESCRIPTION
This PR adds a very tiny contribution to the main execution of the `bilrost` command. Prior to this change, when a signal was received and the http server was asked to shutdown, i.e. rollout restart of the deployment (SIGTERM), it did not have a timeout so the execution could hang there more time than desired.

The change simply adds a 5 second timeout. Not sure if that is enough or if that should come from a parameter, I'll leave that to your thoughts.